### PR TITLE
Saml assertion flow - display error to user if assertion can't be loaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 node_modules/
 .env
 .DS_Store
-data/
 fontpatcher/
 keys/

--- a/Server.js
+++ b/Server.js
@@ -241,10 +241,20 @@ app.get('/refresh', function (req, res) {
 app.get('/samlAssert', function (req, res) {
     // Instantiate Saml Assert service and generate post request
     authInstance = new SamlAssertService(req.query.isSandbox);
-    let postRequest = authInstance.generateSamlAssertRequest();
 
-    // Handle the response of the post request
-    handlePostRequest(postRequest, res);
+    let postRequest;
+    try {
+        postRequest = authInstance.generateSamlAssertRequest();
+    }
+    catch(e) {
+        console.log('Erorr: '+e);
+        res.status(500).end(error);
+    }
+
+    if(postRequest) {
+        // Handle the response of the post request
+        handlePostRequest(postRequest, res);
+    }    
 });
 
 /**

--- a/Server.js
+++ b/Server.js
@@ -246,9 +246,9 @@ app.get('/samlAssert', function (req, res) {
     try {
         postRequest = authInstance.generateSamlAssertRequest();
     }
-    catch(e) {
-        console.log('Erorr: '+e);
-        res.status(500).end(error);
+    catch(error) {
+        console.log('Erorr from generateSamlAssertRequest(): '+error);
+        res.status(500).end('Error occurred: ' + error.message);
     }
 
     if(postRequest) {

--- a/services/samlassert.js
+++ b/services/samlassert.js
@@ -13,11 +13,16 @@ class SamlAssertService extends AuthService {
         const assertionType = 'urn:oasis:names:tc:SAML:2.0:profiles:SSO:browser';
         let endpointUrl = this.getTokenEndpoint();
 
-        // Read assertion XML from file located at 'data/axiomSamlAssertion.xml'. Alternatively, copy-paste XML string below and assign to variable.
+        // Read assertion XML from file located at 'data/axiomSamlAssertion.xml'. Alternatively, copy-paste XML string below.
         const fileLocation = 'data/axiomSamlAssertion.xml';
-        let assertionXml = fs.readFileSync(path.resolve(fileLocation), 'utf8');
-        if(!assertionXml) {
-            throw new Error('Axiom SAML assertion not found at '+fileLocation+'- check the steps for this flow ensure this has been delpoyed');
+        let assertionXml;
+        try {
+            assertionXml = fs.readFileSync(path.resolve(fileLocation), 'utf8');
+        }
+        // If exception, re-throw with more helpful message to be displayed to user
+        catch(e) {
+            console.log(e);
+            throw new Error('Could not load Axiom SAML from '+fileLocation+'- check the instructions for this flow ensure the assertion file has been delpoyed');
         }
         let base64AssertionXml = Buffer.from(assertionXml).toString('base64');
 

--- a/services/samlassert.js
+++ b/services/samlassert.js
@@ -14,7 +14,11 @@ class SamlAssertService extends AuthService {
         let endpointUrl = this.getTokenEndpoint();
 
         // Read assertion XML from file located at 'data/axiomSamlAssertion.xml'. Alternatively, copy-paste XML string below and assign to variable.
-        let assertionXml = fs.readFileSync(path.resolve('data/axiomSamlAssertion.xml'), 'utf8');
+        const fileLocation = 'data/axiomSamlAssertion.xml';
+        let assertionXml = fs.readFileSync(path.resolve(fileLocation), 'utf8');
+        if(!assertionXml) {
+            throw new Error('Axiom SAML assertion not found at '+fileLocation+'- check the steps for this flow ensure this has been delpoyed');
+        }
         let base64AssertionXml = Buffer.from(assertionXml).toString('base64');
 
         // Construct the request body containing grant type, assertion type and assertion. All should be URL encoded.


### PR DESCRIPTION
If assertion not present, readFileSync() was failing with uncaught exception. Added try/catch and an more meaningful error to be displayed back on page

Also removed data/ from gitignore to reduce confusion for anyone adding their own assertion and pushing to heroku