### PR TITLE
Initilise redirect when setting attributes

### DIFF
--- a/services/device.js
+++ b/services/device.js
@@ -30,7 +30,7 @@ class DeviceService extends AuthService {
 
     processCallback(remoteBody) {
         // Return value for redirect
-        let redirect = {};
+        let redirect;
         let error;
 
         // Parse response for device code, interval, verification URI and user code
@@ -42,6 +42,7 @@ class DeviceService extends AuthService {
 
         if (verificationUri) {
             // If verification URI is present, we are in device flow and need to keep polling
+            redirect = {}
             redirect.location = 'deviceOAuth';
             redirect.payload = {
                 verification_uri: verificationUri,


### PR DESCRIPTION
If error set by processCallback(), this leads to exception in the processResponse() function in Server.js. processCallback() always sets redirect to an empty array, so the first if in processResponse() always executes, leading to exception and Heroku app crash when referencing redirect attributes.

An easy way to test error scenario is to disable device authentication in connected app